### PR TITLE
Removed redundant/unused IWebBrowser from MainWindow.xaml.cs

### DIFF
--- a/CefSharp.MinimalExample.Wpf/MainWindow.xaml.cs
+++ b/CefSharp.MinimalExample.Wpf/MainWindow.xaml.cs
@@ -5,22 +5,11 @@ using System.Windows;
 
 namespace CefSharp.MinimalExample.Wpf
 {
-    public partial class MainWindow : Window, INotifyPropertyChanged
+    public partial class MainWindow : Window
     {
-        private IWpfWebBrowser webBrowser;
-        public IWpfWebBrowser WebBrowser
-        {
-            get { return webBrowser; }
-            set { PropertyChanged.ChangeAndNotify(ref webBrowser, value, () => WebBrowser); }
-        }
-
         public MainWindow()
         {
             InitializeComponent();
-
-            DataContext = this;
         }
-
-        public event PropertyChangedEventHandler PropertyChanged;
     }
 }


### PR DESCRIPTION
`MainWindow.xaml` uses the `MainView` View/ViewModel, which contains its own `IWebBrowser`. Removed redundant/unused `IWebBrowser` from `MainWindow.xaml.cs`.
