### PR TITLE
rename x64 so x86 is default configuration

### DIFF
--- a/CefSharp.MinimalExample.sln
+++ b/CefSharp.MinimalExample.sln
@@ -1,26 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.30219.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CefSharp.MinimalExample.Wpf", "CefSharp.MinimalExample.Wpf\CefSharp.MinimalExample.Wpf.csproj", "{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
+		Debug|zNotEnabled_x64 = Debug|zNotEnabled_x64
 		Release|x86 = Release|x86
+		Release|zNotEnabled_x64 = Release|zNotEnabled_x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Debug|x64.ActiveCfg = Debug|x64
-		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Debug|x64.Build.0 = Debug|x64
 		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Debug|x86.ActiveCfg = Debug|x86
 		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Debug|x86.Build.0 = Debug|x86
-		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Release|x64.ActiveCfg = Release|x64
-		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Release|x64.Build.0 = Release|x64
+		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Debug|zNotEnabled_x64.ActiveCfg = Debug|x64
+		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Debug|zNotEnabled_x64.Build.0 = Debug|x64
 		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Release|x86.ActiveCfg = Release|x86
 		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Release|x86.Build.0 = Release|x86
+		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Release|zNotEnabled_x64.ActiveCfg = Release|x64
+		{BE4C3AD0-8DA2-4246-8C63-EEEB7DC197BE}.Release|zNotEnabled_x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hack to make Configuration Manager default "Active Solution Platform" selection to x86 by making x64 appear alphabetically after.  Could instead delete the x64 configuration, but if it is fixed in the future then might be easier if we leave it.  As far as I can tell, switching the setting from the UI is saved to your *.suo :/
