### PR TITLE
Bug fix: URL bar was too trigger happy

### DIFF
--- a/CefSharp.MinimalExample.Wpf/MainWindow.xaml
+++ b/CefSharp.MinimalExample.Wpf/MainWindow.xaml
@@ -31,13 +31,13 @@
             </Grid.ColumnDefinitions>
             <Button Content="Back" Command="{Binding WebBrowser.BackCommand, ElementName=Browser}" Width="50"/>
             <Button Content="Forward" Command="{Binding WebBrowser.ForwardCommand, ElementName=Browser}" Grid.Column="1" Width="60"/>
-            <TextBox x:Name="txtBoxAddress" Text="{Binding Address, ElementName=Browser, FallbackValue=www.google.com}" Grid.Column="2" FontSize="12" BorderBrush="Gray" BorderThickness="1" />
+            <TextBox x:Name="txtBoxAddress" Text="{Binding Address, ElementName=Browser, UpdateSourceTrigger=LostFocus, Mode=TwoWay}" Grid.Column="2" FontSize="12" BorderBrush="Gray" BorderThickness="1" Keyboard.KeyDown="OnTxtBoxAddressKeyDown"/>
             <Button Content="Print..." Command="{Binding WebBrowser.PrintCommand, ElementName=Browser}" Grid.Column="3" Width="50" />
             <Button Content="View source" Command="{Binding WebBrowser.ViewSourceCommand, ElementName=Browser}" Grid.Column="4" Width="75" />
         </Grid>
         <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="0,1">
             <wpf:ChromiumWebBrowser x:Name="Browser"
-                                    Address="{Binding Text, ElementName=txtBoxAddress}">
+                                    Address="www.google.com">
                 <i:Interaction.Behaviors>
                     <behaviours:HoverLinkBehaviour x:Name="HoverLinkBehaviour"/>
                 </i:Interaction.Behaviors>

--- a/CefSharp.MinimalExample.Wpf/MainWindow.xaml.cs
+++ b/CefSharp.MinimalExample.Wpf/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace CefSharp.MinimalExample.Wpf
 {
@@ -7,6 +9,14 @@ namespace CefSharp.MinimalExample.Wpf
         public MainWindow()
         {
             InitializeComponent();
+        }
+
+        private void OnTxtBoxAddressKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                txtBoxAddress.GetBindingExpression(TextBox.TextProperty).UpdateSource();
+            }
         }
     }
 }


### PR DESCRIPTION
It would change the URL in the middle of typing in the URL, making the app extremely unusable.

I debugged this a bit and it was seemingly caused by the double bindings. It seems like a somewhat bizarre way to construct the WPF bindings. Doing it using a single binding instead makes more sense, and the way to trigger the URL change is now the Enter key, or moving the focus away from the URL bar.

I've verified that navigating around still updates the URLs displayed in the URL bar.