### PR TITLE
UI Changes : New Location for Progress bar.

### DIFF
--- a/CefSharp.MinimalExample.Wpf/App.xaml
+++ b/CefSharp.MinimalExample.Wpf/App.xaml
@@ -6,5 +6,6 @@
     <Application.Resources>
         <converter:TitleConverter x:Key="TitleConverter"/>
         <converter:EnvironmentConverter x:Key="EnvironmentConverter" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </Application.Resources>
 </Application>

--- a/CefSharp.MinimalExample.Wpf/Behaviours/TextBoxBindingUpdateOnEnterBehaviour.cs
+++ b/CefSharp.MinimalExample.Wpf/Behaviours/TextBoxBindingUpdateOnEnterBehaviour.cs
@@ -1,0 +1,28 @@
+﻿using System.Windows.Interactivity;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace CefSharp.MinimalExample.Wpf.Behaviours
+{
+    public class TextBoxBindingUpdateOnEnterBehaviour : Behavior<TextBox>
+    {
+        protected override void OnAttached()
+        {
+            AssociatedObject.KeyDown += OnTextBoxKeyDown;
+        }
+
+        protected override void OnDetaching()
+        {
+            AssociatedObject.KeyDown -= OnTextBoxKeyDown;
+        }
+
+        private void OnTextBoxKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                var txtBox = sender as TextBox;
+                txtBox.GetBindingExpression(TextBox.TextProperty).UpdateSource();
+            }
+        }
+    }
+}

--- a/CefSharp.MinimalExample.Wpf/CefSharp.MinimalExample.Wpf.csproj
+++ b/CefSharp.MinimalExample.Wpf/CefSharp.MinimalExample.Wpf.csproj
@@ -103,6 +103,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Behaviours\HoverLinkBehaviour.cs" />
+    <Compile Include="Behaviours\TextBoxBindingUpdateOnEnterBehaviour.cs" />
     <Compile Include="Converter\EnvironmentConverter.cs" />
     <Compile Include="Converter\TitleConverter.cs" />
     <Compile Include="MainWindow.xaml.cs">

--- a/CefSharp.MinimalExample.Wpf/Converter/TitleConverter.cs
+++ b/CefSharp.MinimalExample.Wpf/Converter/TitleConverter.cs
@@ -6,15 +6,14 @@ namespace CefSharp.MinimalExample.Wpf.Converter
 {
     public class TitleConverter : IValueConverter
     {
-        object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-
             return "CefSharp.MinimalExample.Wpf - " + (value ?? "No Title Specified");
         }
 
-        object IValueConverter.ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return System.Windows.Data.Binding.DoNothing;
+            return Binding.DoNothing;
         }
     }
 }

--- a/CefSharp.MinimalExample.Wpf/MainWindow.xaml
+++ b/CefSharp.MinimalExample.Wpf/MainWindow.xaml
@@ -31,25 +31,35 @@
             </Grid.ColumnDefinitions>
             <Button Content="Back" Command="{Binding WebBrowser.BackCommand, ElementName=Browser}" Width="50"/>
             <Button Content="Forward" Command="{Binding WebBrowser.ForwardCommand, ElementName=Browser}" Grid.Column="1" Width="60"/>
-            <TextBox x:Name="txtBoxAddress" Text="{Binding Address, ElementName=Browser, FallbackValue=www.google.com}" Grid.Column="2" FontSize="12" BorderBrush="Gray" BorderThickness="1" />
+            <TextBox x:Name="txtBoxAddress" Text="{Binding Address, ElementName=Browser, FallbackValue=www.google.com}" Grid.Column="2" FontSize="12" BorderBrush="Gray" BorderThickness="1">
+                <i:Interaction.Behaviors>
+                    <behaviours:TextBoxBindingUpdateOnEnterBehaviour />
+                </i:Interaction.Behaviors>
+            </TextBox>
             <Button Content="Print..." Command="{Binding WebBrowser.PrintCommand, ElementName=Browser}" Grid.Column="3" Width="50" />
             <Button Content="View source" Command="{Binding WebBrowser.ViewSourceCommand, ElementName=Browser}" Grid.Column="4" Width="75" />
         </Grid>
         <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="0,1">
             <wpf:ChromiumWebBrowser x:Name="Browser"
-                                    Address="{Binding Text, ElementName=txtBoxAddress}">
+                                    Address="www.google.com">
                 <i:Interaction.Behaviors>
                     <behaviours:HoverLinkBehaviour x:Name="HoverLinkBehaviour"/>
                 </i:Interaction.Behaviors>
             </wpf:ChromiumWebBrowser>
         </Border>
+        <ProgressBar IsIndeterminate="{Binding IsLoading, ElementName=Browser}"
+                     HorizontalAlignment="Stretch"
+                     VerticalAlignment="Top"
+                     Width="Auto"
+                     Grid.Row="1"
+                     Height="2"
+                     Visibility="{Binding IsLoading, ElementName=Browser, Converter={StaticResource BooleanToVisibilityConverter}}"
+                     BorderThickness="0" />
         <StatusBar Grid.Row="2" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
             <StatusBar.ItemsPanel>
                 <ItemsPanelTemplate>
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
@@ -57,19 +67,11 @@
                     </Grid>
                 </ItemsPanelTemplate>
             </StatusBar.ItemsPanel>
-            <StatusBarItem>
-                <ProgressBar HorizontalAlignment="Right"
-                             IsIndeterminate="{Binding IsLoading, ElementName=Browser}"
-                             Width="100"
-                             Height="16"
-                             Margin="3" />
+            <StatusBarItem Grid.Column="0">
+                <TextBlock Text="{Binding HoverLink, ElementName=HoverLinkBehaviour}" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
             </StatusBarItem>
             <Separator Grid.Column="1" />
             <StatusBarItem Grid.Column="2">
-                <TextBlock Text="{Binding HoverLink, ElementName=HoverLinkBehaviour}" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
-            </StatusBarItem>
-            <Separator Grid.Column="3" />
-            <StatusBarItem Grid.Column="4">
                 <TextBlock HorizontalAlignment="Right" TextAlignment="Right" Grid.Column="3" VerticalAlignment="Center">
                 Chromium: <Run Text="{Binding Source={x:Static cef:Cef.ChromiumVersion}, Mode=OneTime}" />, CEF: <Run Text="{Binding Source={x:Static cef:Cef.CefVersion}, Mode=OneTime}" />, CefSharp: <Run Text="{Binding Source={x:Static cef:Cef.CefSharpVersion}, Mode=OneTime}"/>, Environment: <Run Text="{Binding Converter={StaticResource EnvironmentConverter}, Mode=OneTime}"/>
                 </TextBlock>


### PR DESCRIPTION
1. Made more space for links hover in statusbar - Moved Progress Bar below addressbar.
    a) Thinly visible when loading, hides when loaded.
    b) No flickering as progress bar and browser share same row.
2. Load page when hit Enter in Addressbar - Behaviour for that.
3. Refactor.

![capture](https://user-images.githubusercontent.com/26463468/33796386-4556db44-dd19-11e7-91c7-3428c8d633f5.jpg)
