### PR TITLE
Add .NET Core 3.0 WinForms/WPF/OffScreen examples

### DIFF
--- a/CefSharp.MinimalExample.OffScreen/CefSharp.MinimalExample.OffScreen.netcore.csproj
+++ b/CefSharp.MinimalExample.OffScreen/CefSharp.MinimalExample.OffScreen.netcore.csproj
@@ -1,26 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <RootNamespace>CefSharp.MinimalExample.Wpf</RootNamespace>
-    <ApplicationIcon>chromium-256.ico</ApplicationIcon>
+    <UseWindowsForms>true</UseWindowsForms>
+    <RootNamespace>CefSharp.MinimalExample.OffScreen</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Platforms>x86;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Windows.Interactivity.WPF" Version="2.0.20525" />
-    <PackageReference Include="CefSharp.Wpf" Version="75.1.141" />
+    <PackageReference Include="CefSharp.OffScreen" Version="75.1.141" />
 
     <!-- TODO: This additional references should not be needed any more once the 
-         downstream package (CefSharp.Wpf) specifies dependencies for ".NETCoreApp3.0". -->
+         downstream package (CefSharp.OffScreen) specifies dependencies for ".NETCoreApp3.0". -->
     <PackageReference Include="CefSharp.Common" Version="75.1.141" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- TODO: These updates are currently required because CefSharp.Wpf specifies
+    <!-- TODO: These updates are currently required because CefSharp.OffScreen specifies
          <Private>false</Private>, which means these libraries will not be specified in
          the .deps.json file, and so the CoreCLR wouldn't load these. -->
     <Reference Update="CefSharp">
@@ -29,7 +27,7 @@
     <Reference Update="CefSharp.Core">
       <Private>true</Private>
     </Reference>
-    <Reference Update="CefSharp.Wpf">
+    <Reference Update="CefSharp.OffScreen">
       <Private>true</Private>
     </Reference>
   </ItemGroup>

--- a/CefSharp.MinimalExample.OffScreen/CefSharp.MinimalExample.OffScreen.netcore.csproj
+++ b/CefSharp.MinimalExample.OffScreen/CefSharp.MinimalExample.OffScreen.netcore.csproj
@@ -10,11 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CefSharp.OffScreen" Version="75.1.141" />
-
-    <!-- TODO: This additional references should not be needed any more once the 
-         downstream package (CefSharp.OffScreen) specifies dependencies for ".NETCoreApp3.0". -->
-    <PackageReference Include="CefSharp.Common" Version="75.1.141" />
+    <PackageReference Include="CefSharp.OffScreen" Version="75.1.142" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CefSharp.MinimalExample.OffScreen/Program.cs
+++ b/CefSharp.MinimalExample.OffScreen/Program.cs
@@ -88,7 +88,10 @@ namespace CefSharp.MinimalExample.OffScreen
                         Console.WriteLine("Screenshot saved.  Launching your default image viewer...");
 
                         // Tell Windows to launch the saved image.
-                        Process.Start(screenshotPath);
+                        Process.Start(new ProcessStartInfo(screenshotPath)
+                        {
+                            UseShellExecute = true
+                        });
 
                         Console.WriteLine("Image viewer launched.  Press any key to exit.");			
                     }, TaskScheduler.Default);

--- a/CefSharp.MinimalExample.OffScreen/Program.cs
+++ b/CefSharp.MinimalExample.OffScreen/Program.cs
@@ -90,6 +90,7 @@ namespace CefSharp.MinimalExample.OffScreen
                         // Tell Windows to launch the saved image.
                         Process.Start(new ProcessStartInfo(screenshotPath)
                         {
+                            // UseShellExecute is false by default on .NET Core.
                             UseShellExecute = true
                         });
 

--- a/CefSharp.MinimalExample.WinForms/BrowserForm.cs
+++ b/CefSharp.MinimalExample.WinForms/BrowserForm.cs
@@ -33,9 +33,21 @@ namespace CefSharp.MinimalExample.WinForms
             browser.TitleChanged += OnBrowserTitleChanged;
             browser.AddressChanged += OnBrowserAddressChanged;
 
+            var version = string.Format("Chromium: {0}, CEF: {1}, CefSharp: {2}",
+               Cef.ChromiumVersion, Cef.CefVersion, Cef.CefSharpVersion);
+
+#if NETCOREAPP
+            // .NET Core
+            var environment = string.Format("Environment: {0}, Runtime: {1}",
+                System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
+                System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+#else
+            // .NET Framework
             var bitness = Environment.Is64BitProcess ? "x64" : "x86";
-            var version = String.Format("Chromium: {0}, CEF: {1}, CefSharp: {2}, Environment: {3}", Cef.ChromiumVersion, Cef.CefVersion, Cef.CefSharpVersion, bitness);
-            DisplayOutput(version);
+            var environment = String.Format("Environment: {0}", bitness);            
+#endif
+
+            DisplayOutput(string.Format("{0}, {1}", version, environment));
         }
 
         private void OnIsBrowserInitializedChanged(object sender, EventArgs e)

--- a/CefSharp.MinimalExample.WinForms/CefSharp.MinimalExample.WinForms.netcore.csproj
+++ b/CefSharp.MinimalExample.WinForms/CefSharp.MinimalExample.WinForms.netcore.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <RootNamespace>CefSharp.MinimalExample.WinForms</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Platforms>x86;x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CefSharp.WinForms" Version="75.1.141" />
+
+    <!-- TODO: This additional references should not be needed any more once the 
+         downstream package (CefSharp.WinForms) specifies dependencies for ".NETCoreApp3.0". -->
+    <PackageReference Include="CefSharp.Common" Version="75.1.141" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- TODO: These updates are currently required because CefSharp.WinForms specifies
+         <Private>false</Private>, which means these libraries will not be specified in
+         the .deps.json file, and so the CoreCLR wouldn't load these. -->
+    <Reference Update="CefSharp">
+      <Private>true</Private>
+    </Reference>
+    <Reference Update="CefSharp.Core">
+      <Private>true</Private>
+    </Reference>
+    <Reference Update="CefSharp.WinForms">
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/CefSharp.MinimalExample.WinForms/CefSharp.MinimalExample.WinForms.netcore.csproj
+++ b/CefSharp.MinimalExample.WinForms/CefSharp.MinimalExample.WinForms.netcore.csproj
@@ -10,11 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CefSharp.WinForms" Version="75.1.141" />
-
-    <!-- TODO: This additional references should not be needed any more once the 
-         downstream package (CefSharp.WinForms) specifies dependencies for ".NETCoreApp3.0". -->
-    <PackageReference Include="CefSharp.Common" Version="75.1.141" />
+    <PackageReference Include="CefSharp.WinForms" Version="75.1.142" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CefSharp.MinimalExample.Wpf/CefSharp.MinimalExample.Wpf.netcore.csproj
+++ b/CefSharp.MinimalExample.Wpf/CefSharp.MinimalExample.Wpf.netcore.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>CefSharp.MinimalExample.Wpf</RootNamespace>
+    <ApplicationIcon>chromium-256.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Platforms>x86;x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Windows.Interactivity.WPF" Version="2.0.20525" />
+    <PackageReference Include="CefSharp.Wpf" Version="75.1.141" />
+
+    <!-- TODO: This additional references should not be needed any more once the 
+         downstream package (CefSharp.WinForms) specifies dependencies for ".NETCoreApp3.0". -->
+    <PackageReference Include="CefSharp.Common" Version="75.1.141" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- TODO: These updates are currently required because CefSharp.WinForms specifies
+         <Private>false</Private>, which means these libraries will not be specified in
+         the .deps.json file, and so the CoreCLR wouldn't load these. -->
+    <Reference Update="CefSharp">
+      <Private>true</Private>
+    </Reference>
+    <Reference Update="CefSharp.Core">
+      <Private>true</Private>
+    </Reference>
+    <Reference Update="CefSharp.Wpf">
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/CefSharp.MinimalExample.Wpf/CefSharp.MinimalExample.Wpf.netcore.csproj
+++ b/CefSharp.MinimalExample.Wpf/CefSharp.MinimalExample.Wpf.netcore.csproj
@@ -12,11 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Windows.Interactivity.WPF" Version="2.0.20525" />
-    <PackageReference Include="CefSharp.Wpf" Version="75.1.141" />
-
-    <!-- TODO: This additional references should not be needed any more once the 
-         downstream package (CefSharp.Wpf) specifies dependencies for ".NETCoreApp3.0". -->
-    <PackageReference Include="CefSharp.Common" Version="75.1.141" />
+    <PackageReference Include="CefSharp.Wpf" Version="75.1.142" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CefSharp.MinimalExample.netcore.sln
+++ b/CefSharp.MinimalExample.netcore.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CefSharp.MinimalExample.Win
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CefSharp.MinimalExample.Wpf.netcore", "CefSharp.MinimalExample.Wpf\CefSharp.MinimalExample.Wpf.netcore.csproj", "{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CefSharp.MinimalExample.OffScreen.netcore", "CefSharp.MinimalExample.OffScreen\CefSharp.MinimalExample.OffScreen.netcore.csproj", "{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -31,6 +33,14 @@ Global
 		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Release|x64.Build.0 = Release|x64
 		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Release|x86.ActiveCfg = Release|x86
 		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Release|x86.Build.0 = Release|x86
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Debug|x64.ActiveCfg = Debug|x64
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Debug|x64.Build.0 = Debug|x64
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Debug|x86.ActiveCfg = Debug|x86
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Debug|x86.Build.0 = Debug|x86
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Release|x64.ActiveCfg = Release|x64
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Release|x64.Build.0 = Release|x64
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Release|x86.ActiveCfg = Release|x86
+		{AB1B7B81-D472-43B2-AFE3-DE5D1B22B9CE}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CefSharp.MinimalExample.netcore.sln
+++ b/CefSharp.MinimalExample.netcore.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29230.61
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CefSharp.MinimalExample.WinForms.netcore", "CefSharp.MinimalExample.WinForms\CefSharp.MinimalExample.WinForms.netcore.csproj", "{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CefSharp.MinimalExample.Wpf.netcore", "CefSharp.MinimalExample.Wpf\CefSharp.MinimalExample.Wpf.netcore.csproj", "{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Debug|x64.ActiveCfg = Debug|x64
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Debug|x64.Build.0 = Debug|x64
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Debug|x86.ActiveCfg = Debug|x86
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Debug|x86.Build.0 = Debug|x86
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Release|x64.ActiveCfg = Release|x64
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Release|x64.Build.0 = Release|x64
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Release|x86.ActiveCfg = Release|x86
+		{4E27910D-3B6C-41C1-84B4-A05C58EE8AE8}.Release|x86.Build.0 = Release|x86
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Debug|x64.ActiveCfg = Debug|x64
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Debug|x64.Build.0 = Debug|x64
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Debug|x86.ActiveCfg = Debug|x86
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Debug|x86.Build.0 = Debug|x86
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Release|x64.ActiveCfg = Release|x64
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Release|x64.Build.0 = Release|x64
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Release|x86.ActiveCfg = Release|x86
+		{83E2C9C4-2967-4A49-8B2A-D31D33DCFB03}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {81E9E2D5-A36B-4EB6-82A4-BAE734AEB0CC}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CefSharp.MinimalExample
 
 Minimal example of how the CefSharp library can be used using the official `Nuget` packages with .NET Framework
-projects (`CefSharp.MnimalExample.sln`) and .NET Core projects (`CefSharp.MinimalExample.netcore.sln`). 
+projects (`CefSharp.MinimalExample.sln`) and .NET Core projects (`CefSharp.MinimalExample.netcore.sln`). 
 
 Includes examples for
 - WinForms

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-CefSharp.MinimalExample
-=======================
+# CefSharp.MinimalExample
 
-Minimal example of how the CefSharp library can be used using the official `Nuget` packages. 
+Minimal example of how the CefSharp library can be used using the official `Nuget` packages with .NET Framework
+projects (`CefSharp.MnimalExample.sln`) and .NET Core projects (`CefSharp.MinimalExample.netcore.sln`). 
 
 Includes examples for
 - WinForms
@@ -10,3 +10,14 @@ Includes examples for
  
 
 For a more complete example of each project see the main `CefSharp` repository.
+
+## .NET Core support
+As of version `75.1.142`, the CefSharp NuGet packages can be used with .NET Core 3.0 projects (as shown by the examples). However, the current versions have some limitations that you should be aware of:
+- The target machine still needs to have .NET Framework 4.5.2 or higher installed, as the `CefSharp.BrowserSubprocess.exe` is still used.
+- The project file needs to update the references of `CefSharp.WinForms`/`CefSharp.WPF`/`CefSharp.OffScreen`, as well as `CefSharp.Core` and `CefSharp` to use `<Private>true</Private>`, as otherwise the CoreCLR would not load these libraries as they would not be specified in the `.deps.json` file.
+- When publishing a self-contained app using a runtime identifier `win-x64` or `win-x86`, you need to set the `Platform` property to `x64` or `x86`; as otherwise it would be `AnyCPU` and the check in the `.targets` file of the NuGet package would fail.<br>
+  Example:
+  - x86: `dotnet publish -f netcoreapp3.0 -r win-x86 -p:Platform=x86`
+  - x64: `dotnet publish -f netcoreapp3.0 -r win-x64 -p:Platform=x64`
+
+It is possible to publish the application as single EXE file by adding `-p:PublishSingleFile=true`.


### PR DESCRIPTION
Add a WinForms, WPF and OffScreen example using .NET Core 3.0. For this, I added new `.netcore.csproj` files in the existing project folders, and (for WinForms) adjusted the output of the status bar to display the .NET Core version.
See https://github.com/cefsharp/CefSharp/issues/2796

Current limitations of using `CefSharp.WinForms`, `CefSharp.Wpf` and `CefSharp.OffScreen` with .NET Core 3.0:
* You still need to have .NET Framework 4.5.2 or higher installed, as the `CefSharp.BrowserSubprocess.exe` is still used.
* The project file needs to update the references of `CefSharp.WinForms`/`CefSharp.WPF`/`CefSharp.OffScreen`, as well as `CefSharp.Core` and `CefSharp` to use `<Private>true</Private>`, as otherwise the CoreCLR would not load these libraries as they would not be specified in the `.deps.json` file.
* When publishing a self-contained app using a runtime identifier `win-x64` or `win-x86`, you need to set the `Platform` property to `x64` or `x86`; as otherwise it would be `AnyCPU` and the check in the `.targets` file of the NuGet package would fail.
Example:
x86: `dotnet publish -f netcoreapp3.0 -r win-x86 -p:Platform=x86`
x64: `dotnet publish -f netcoreapp3.0 -r win-x64 -p:Platform=x64`

The application can also be published as single EXE file by adding `-p:PublishSingleFile=true`.

Thank you!