### PR TITLE
.Net Core - Don't perform a dependency check

### DIFF
--- a/CefSharp.MinimalExample.OffScreen/Program.netcore.cs
+++ b/CefSharp.MinimalExample.OffScreen/Program.netcore.cs
@@ -46,8 +46,9 @@ namespace CefSharp.MinimalExample.OffScreen
                 BrowserSubprocessPath = exePath
             };
 
-            //Perform dependency check to make sure all relevant resources are in our output directory.
-            Cef.Initialize(settings, performDependencyCheck: true, browserProcessHandler: null);
+            // For .NET Core, don't perform a dependency check, to allow publishing single-file
+            // executables.
+            Cef.Initialize(settings, performDependencyCheck: false, browserProcessHandler: null);
 
             // Create the offscreen Chromium browser.
             browser = new ChromiumWebBrowser(testUrl);

--- a/CefSharp.MinimalExample.WinForms/Program.netcore.cs
+++ b/CefSharp.MinimalExample.WinForms/Program.netcore.cs
@@ -41,8 +41,9 @@ namespace CefSharp.MinimalExample.WinForms
             //Enables WebRTC
             settings.CefCommandLineArgs.Add("enable-media-stream");
 
-            //Perform dependency check to make sure all relevant resources are in our output directory.
-            Cef.Initialize(settings, performDependencyCheck: true, browserProcessHandler: null);
+            // For .NET Core, don't perform a dependency check, to allow publishing single-file
+            // executables.
+            Cef.Initialize(settings, performDependencyCheck: false, browserProcessHandler: null);
 
             var browser = new BrowserForm();
             Application.Run(browser);

--- a/CefSharp.MinimalExample.Wpf/Program.netcore.cs
+++ b/CefSharp.MinimalExample.Wpf/Program.netcore.cs
@@ -39,8 +39,9 @@ namespace CefSharp.MinimalExample.Wpf
             //Enables WebRTC
             settings.CefCommandLineArgs.Add("enable-media-stream");
 
-            //Perform dependency check to make sure all relevant resources are in our output directory.
-            Cef.Initialize(settings, performDependencyCheck: true, browserProcessHandler: null);
+            // For .NET Core, don't perform a dependency check, to allow publishing single-file
+            // executables.
+            Cef.Initialize(settings, performDependencyCheck: false, browserProcessHandler: null);
 
             var app = new App();
             app.InitializeComponent();


### PR DESCRIPTION
In .NET Core, you can publish a single-file executable with `-p:PublishSingleFile=true`. This results in a `EXE` file where all dependencies are embedded. When running the EXE, it will extract that files into a temporary directory, and (AFAIK) set the Windows library search path to load native libraries from that directory (in addition to .NET assemblies).

However, when we set the `CefSettings.BrowserSubprocessPath` to the current EXE path, the `DenepdencyChecker` will complain as that directory is not the one which contains the libraries. E.g.
* In Folder `CefSharp.MinimalExample.WinForms`, run 
```
dotnet publish CefSharp.MinimalExample.WinForms.netcore.csproj -f netcoreapp3.0 -r win-x64 -p:PublishSingleFile=true
```
* Run `bin\Debug\netcoreapp3.0\win-x64\publish\CefSharp.MinimalExample.WinForms.netcore.exe`
* It will crash with:
```text
System.Exception: Unable to locate required Cef/CefSharp dependencies:
Missing:C:\Users\developer4\Desktop\CefSharp.MinimalExample\CefSharp.MinimalExample.WinForms\bin\Debug\netcoreapp3.0\win-x64\publish\libcef.dll
Missing:C:\Users\developer4\Desktop\CefSharp.MinimalExample\CefSharp.MinimalExample.WinForms\bin\Debug\netcoreapp3.0\win-x64\publish\icudtl.dat
Missing:C:\Users\developer4\Desktop\CefSharp.MinimalExample\CefSharp.MinimalExample.WinForms\bin\Debug\netcoreapp3.0\win-x64\publish\natives_blob.bin
(...)
````

By disabling the dependency check, the single-file executable will run successfully.