### PR TITLE
Winform unload

### DIFF
--- a/CefSharp.MinimalExample.WinForms/BrowserForm.cs
+++ b/CefSharp.MinimalExample.WinForms/BrowserForm.cs
@@ -156,6 +156,10 @@ namespace CefSharp.MinimalExample.WinForms
 
         private void ExitMenuItemClick(object sender, EventArgs e)
         {
+            // Prevent a race condition where browser.Dispose tears down it's control
+            // (before all browser cleanup has finished)
+            // https://github.com/cefsharp/CefSharp/issues/1574
+            // There are better/more complicated ways to handle this too
             toolStripContainer.ContentPanel.Controls.Remove(browser);
             browser.Dispose();
             Cef.Shutdown();

--- a/CefSharp.MinimalExample.WinForms/BrowserForm.cs
+++ b/CefSharp.MinimalExample.WinForms/BrowserForm.cs
@@ -156,6 +156,7 @@ namespace CefSharp.MinimalExample.WinForms
 
         private void ExitMenuItemClick(object sender, EventArgs e)
         {
+            toolStripContainer.ContentPanel.Controls.Remove(browser);
             browser.Dispose();
             Cef.Shutdown();
             Close();


### PR DESCRIPTION
In the WinForms minimal example, I noticed an issue where the "onunload" event doesn't seem to be firing if you click File > Exit. I think this is related to [CefSharp issue #1574](https://github.com/cefsharp/CefSharp/issues/1574), where there's a bit of a race condition when you call `browser.Dispose()` before removing the browser from the holding control.

In my case, the website I'm trying to embed relies on the onunload event to fire an Ajax/fetch request that logs the user out. With the current example setup, the event is firing but (almost) every time the browser is torn down before the Ajax can send. I can even see the TCP/TLS connection for my Ajax call start (in Fiddler) but then don't see the request body sent out.

If I update the example to remove the browser from the control before Disposing the browser, I consistently see my calls complete!
```
toolStripContainer.ContentPanel.Controls.Remove(browser);
```

I think it would make sense to add this to the minimal example to show others a simple way to handle this, with a comment referencing the issue above. There are more complicated ways to handle this like implementing `ILifespanHandler.DoClose`. That and more already seems to be covered in the [larger WinForms example](https://github.com/cefsharp/CefSharp/tree/master/CefSharp.WinForms.Example).